### PR TITLE
WIP: feature/task_53_Warning when tmodel extends own tmodel - (Task #53)

### DIFF
--- a/de.dlr.sc.overtarget.language.tests/src/de/dlr/sc/overtarget/language/validation/OvertargetValidatorTest.xtend
+++ b/de.dlr.sc.overtarget.language.tests/src/de/dlr/sc/overtarget/language/validation/OvertargetValidatorTest.xtend
@@ -39,7 +39,6 @@ class OvertargetValidatorTest {
 
 	@Test
 	def void testCheckIfWorkingSysUsed() {
-
 		val workingSystemUsed = '''
 			Target __synthetic0 {
 				WorkingSystem cocoa
@@ -49,5 +48,15 @@ class OvertargetValidatorTest {
 		workingSystemUsed.parse.assertWarning(
 		TargetmodelPackage.Literals.TARGET_MODEL, OvertargetValidator.DEPRECATED_WS_STATEMENT, 'Please use WindowingSystem instead of WorkingSystem!'
 		)
+	}
+	
+	@Test
+	def void testCheckIfTmodelExtendsOwnTmodel() {
+		val tmodelExtendsOwnTmodel = '''
+			Target tmodel extends tmodel {
+			}
+		'''
+		
+		tmodelExtendsOwnTmodel.parse.assertError(TargetmodelPackage.Literals.TARGET_MODEL, OvertargetValidator.TMODEL_EXTENDS_OWN_TMODEL)
 	}
 }

--- a/de.dlr.sc.overtarget.language.tests/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidatorTest.java
+++ b/de.dlr.sc.overtarget.language.tests/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidatorTest.java
@@ -67,4 +67,19 @@ public class OvertargetValidatorTest {
       throw Exceptions.sneakyThrow(_e);
     }
   }
+  
+  @Test
+  public void testCheckIfTmodelExtendsOwnTmodel() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("Target tmodel extends tmodel {");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final String tmodelExtendsOwnTmodel = _builder.toString();
+      this._validationTestHelper.assertError(this._parseHelper.parse(tmodelExtendsOwnTmodel), TargetmodelPackage.Literals.TARGET_MODEL, OvertargetValidator.TMODEL_EXTENDS_OWN_TMODEL);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
 }

--- a/de.dlr.sc.overtarget.language/src/de/dlr/sc/overtarget/language/validation/OvertargetValidator.xtend
+++ b/de.dlr.sc.overtarget.language/src/de/dlr/sc/overtarget/language/validation/OvertargetValidator.xtend
@@ -37,4 +37,14 @@ class OvertargetValidator extends AbstractOvertargetValidator {
 			warning('Please use WindowingSys instead of WorkingSys!', target, TargetmodelPackage.eINSTANCE.targetModel_Ws)
 		}
 	}
+	
+	@Check
+	def checkIfTmodelExtendsOwnTmodel(TargetModel target) {
+		var tmodelName = target.name;
+		var extendModel = target.super
+		var extendName = extendModel.name
+		if (tmodelName.equals(extendName)) {
+			warning('A target cannot extend its own target.', target, TargetmodelPackage.eINSTANCE.targetModel_Super)
+		}
+	}
 }

--- a/de.dlr.sc.overtarget.language/src/de/dlr/sc/overtarget/language/validation/OvertargetValidator.xtend
+++ b/de.dlr.sc.overtarget.language/src/de/dlr/sc/overtarget/language/validation/OvertargetValidator.xtend
@@ -53,13 +53,15 @@ class OvertargetValidator extends AbstractOvertargetValidator {
 		}
 	}
 	
+	public static val TMODEL_EXTENDS_OWN_TMODEL = "tmodelExtendsOwnTmodel"
+	
 	@Check
 	def checkIfTmodelExtendsOwnTmodel(TargetModel target) {
 		var tmodelName = target.name;
 		var extendModel = target.super
 		var extendName = extendModel.name
 		if (tmodelName.equals(extendName)) {
-			error('A target cannot extend its own target.', target, TargetmodelPackage.eINSTANCE.targetModel_Super)
+			error('A target cannot extend its own target.', target, TargetmodelPackage.eINSTANCE.targetModel_Super, TMODEL_EXTENDS_OWN_TMODEL)
 		}
 	}
 }

--- a/de.dlr.sc.overtarget.language/src/de/dlr/sc/overtarget/language/validation/OvertargetValidator.xtend
+++ b/de.dlr.sc.overtarget.language/src/de/dlr/sc/overtarget/language/validation/OvertargetValidator.xtend
@@ -44,7 +44,7 @@ class OvertargetValidator extends AbstractOvertargetValidator {
 		var extendModel = target.super
 		var extendName = extendModel.name
 		if (tmodelName.equals(extendName)) {
-			warning('A target cannot extend its own target.', target, TargetmodelPackage.eINSTANCE.targetModel_Super)
+			error('A target cannot extend its own target.', target, TargetmodelPackage.eINSTANCE.targetModel_Super)
 		}
 	}
 }

--- a/de.dlr.sc.overtarget.language/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidator.java
+++ b/de.dlr.sc.overtarget.language/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidator.java
@@ -57,6 +57,8 @@ public class OvertargetValidator extends AbstractOvertargetValidator {
     }
   }
   
+  public static final String TMODEL_EXTENDS_OWN_TMODEL = "tmodelExtendsOwnTmodel";
+  
   @Check
   public void checkIfTmodelExtendsOwnTmodel(final TargetModel target) {
     String tmodelName = target.getName();
@@ -64,7 +66,7 @@ public class OvertargetValidator extends AbstractOvertargetValidator {
     String extendName = extendModel.getName();
     boolean _equals = tmodelName.equals(extendName);
     if (_equals) {
-      this.error("A target cannot extend its own target.", target, TargetmodelPackage.eINSTANCE.getTargetModel_Super());
+      this.error("A target cannot extend its own target.", target, TargetmodelPackage.eINSTANCE.getTargetModel_Super(), OvertargetValidator.TMODEL_EXTENDS_OWN_TMODEL);
     }
   }
 }

--- a/de.dlr.sc.overtarget.language/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidator.java
+++ b/de.dlr.sc.overtarget.language/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidator.java
@@ -49,7 +49,7 @@ public class OvertargetValidator extends AbstractOvertargetValidator {
     String extendName = extendModel.getName();
     boolean _equals = tmodelName.equals(extendName);
     if (_equals) {
-      this.warning("A target cannot extend its own target.", target, TargetmodelPackage.eINSTANCE.getTargetModel_Super());
+      this.error("A target cannot extend its own target.", target, TargetmodelPackage.eINSTANCE.getTargetModel_Super());
     }
   }
 }

--- a/de.dlr.sc.overtarget.language/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidator.java
+++ b/de.dlr.sc.overtarget.language/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidator.java
@@ -41,4 +41,15 @@ public class OvertargetValidator extends AbstractOvertargetValidator {
       this.warning("Please use WindowingSys instead of WorkingSys!", target, TargetmodelPackage.eINSTANCE.getTargetModel_Ws());
     }
   }
+  
+  @Check
+  public void checkIfTmodelExtendsOwnTmodel(final TargetModel target) {
+    String tmodelName = target.getName();
+    TargetModel extendModel = target.getSuper();
+    String extendName = extendModel.getName();
+    boolean _equals = tmodelName.equals(extendName);
+    if (_equals) {
+      this.warning("A target cannot extend its own target.", target, TargetmodelPackage.eINSTANCE.getTargetModel_Super());
+    }
+  }
 }


### PR DESCRIPTION
Overtarget validator throws a warning when a target extends its own tmodel

![grafik](https://user-images.githubusercontent.com/56025362/75669060-9e4f8b00-5c7a-11ea-912f-2d278b1f3933.png)


TO DO: Auto-completion is still suggesting the own target as a super target.
---
closes #53: Throw warning when tmodel extends own tmodel