### PR TITLE
Added a new expressions definition - (Task #82)

### DIFF
--- a/de.dlr.sc.overtarget.language.ui/plugin.xml
+++ b/de.dlr.sc.overtarget.language.ui/plugin.xml
@@ -76,6 +76,16 @@
 					</with>
 			</and>
 		</definition>
+		<definition id="de.dlr.sc.overtarget.language.Overtarget.opened">
+			<and>
+				<reference definitionId="isActiveEditorAnInstanceOfXtextEditor"/>
+					<with variable="activeEditor">
+						<test property="org.eclipse.xtext.ui.editor.XtextEditor.languageName" 
+							value="de.dlr.sc.overtarget.language.Overtarget" 
+							forcePluginActivation="true"/>
+					</with>
+			</and>
+		</definition>
 	</extension>
 	<extension
 		point="org.eclipse.ui.preferencePages">
@@ -435,7 +445,7 @@
 			<visibleWhen
 				checkEnabled="false">
 				<reference
-					definitionId="isActiveEditorAnInstanceOfXtextEditor">
+					definitionId="de.dlr.sc.overtarget.language.Overtarget.opened">
 				</reference>
 			</visibleWhen>
 		</command>
@@ -445,7 +455,7 @@
      <visibleWhen
            checkEnabled="false">
         <reference
-              definitionId="isActiveEditorAnInstanceOfXtextEditor">
+              definitionId="de.dlr.sc.overtarget.language.Overtarget.opened">
         </reference>
      </visibleWhen>
   </command>
@@ -455,7 +465,7 @@
 				<visibleWhen
 					checkEnabled="false">
 					<reference
-						definitionId="isActiveEditorAnInstanceOfXtextEditor">
+						definitionId="de.dlr.sc.overtarget.language.Overtarget.opened">
 					</reference>
 				</visibleWhen>
 		</command>


### PR DESCRIPTION
now only when a file with the extension ".tmodel" is opened in the
editor, the toolbar appears.

xtend file
![grafik](https://user-images.githubusercontent.com/56025362/79735736-045ea300-82f9-11ea-9333-f7a0f1e9e7eb.png)

tmodel file
![grafik](https://user-images.githubusercontent.com/56025362/79735756-0de80b00-82f9-11ea-8b3b-7474bdac3830.png)

closes #82 
---
Task #82: Bug: overtarget toolbar appears when xtend editors are opened