### PR TITLE
Current target not set as active anymore - (Task #103)

### DIFF
--- a/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.xtend
+++ b/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.xtend
@@ -52,7 +52,7 @@ class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
 	
 	@Fix(Diagnostic.LINKING_DIAGNOSTIC)
 	def fixCannotResolveReference(Issue issue, IssueResolutionAcceptor acceptor) {
-		acceptor.accept(issue, 'Use temporary target to resolve tmodel references', 'Generates a temporary target for resolving tmodel references and sets it as active target. \n After resolving the references of this target, it is set as active target again.', '', 
+		acceptor.accept(issue, 'Use temporary target to resolve tmodel references', 'Generates a temporary target for resolving tmodel references and sets it as active target.', '', 
 			new IModification() {
 			
 			override apply(IModificationContext context) throws Exception {
@@ -76,9 +76,7 @@ class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
 						val targetForReferencesFile = refTargetHelper.findTargetForReferencesFile(file, outputDirectory)
 						targetPlatHelper.asActiveTarget = targetForReferencesFile;
 						
-						//find original targetFile and set it as active target
-						val targetFile = refTargetHelper.findTargetFileInProject(file, outputDirectory)
-						targetPlatHelper.asActiveTarget = targetFile
+						genHandler.runGeneration(input);
 					}
 				}
 			}

--- a/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.java
+++ b/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.java
@@ -59,7 +59,7 @@ public class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
   
   @Fix(Diagnostic.LINKING_DIAGNOSTIC)
   public void fixCannotResolveReference(final Issue issue, final IssueResolutionAcceptor acceptor) {
-    acceptor.accept(issue, "Use temporary target to resolve tmodel references", "Generates a temporary target for resolving tmodel references and sets it as active target. \n After resolving the references of this target, it is set as active target again.", "", 
+    acceptor.accept(issue, "Use temporary target to resolve tmodel references", "Generates a temporary target for resolving tmodel references and sets it as active target.", "", 
       new IModification() {
         @Override
         public void apply(final IModificationContext context) throws Exception {
@@ -80,8 +80,7 @@ public class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
               final String outputDirectory = genHandler.getOutputConfigurations(input);
               final IFile targetForReferencesFile = refTargetHelper.findTargetForReferencesFile(file, outputDirectory);
               targetPlatHelper.setAsActiveTarget(targetForReferencesFile);
-              final IFile targetFile = refTargetHelper.findTargetFileInProject(file, outputDirectory);
-              targetPlatHelper.setAsActiveTarget(targetFile);
+              genHandler.runGeneration(input);
             }
           }
         }


### PR DESCRIPTION
only the targetForReferences is set as active when using quick fix

message for quickFix adjusted.
---
Task #103: only set targetForReferences in quickFix