### PR TITLE
Task 90 quick fix correct tmodel name

### DIFF
--- a/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.xtend
+++ b/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.xtend
@@ -105,28 +105,22 @@ class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
 				val input = ite.editorInput
 				val fileEditorInput = input as IFileEditorInput
 				val file = fileEditorInput.file
+				val fileName = file.name.replace(".tmodel", "")
+
 				val uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
 				val project = file.getProject();
 				val rs = resourceSetProvider.get(project);
 				val r = rs.getResource(uri, true);
-				
 				val model = r.contents.get(0) as TargetFile
-				val modelName = model.name
-				
-				val targetKeyword = grammarAccess.KEYWORDAccess.targetKeyword_1.value
-				val targetLibraryKeyword = grammarAccess.targetLibraryRule.name
-				val WHITESPACE_SEPARATOR = 1
 				
 				val xtextDocument = context.xtextDocument
-				val fileName = editor.title.replace(".tmodel", "")
 				
 				if (model instanceof TargetModel) {
-					xtextDocument.replace(issue.offset + WHITESPACE_SEPARATOR + targetKeyword.length, modelName.length, fileName)
+					xtextDocument.replace(issue.offset, issue.length, fileName)
 				} else if (model instanceof TargetLibrary) {
-					xtextDocument.replace(issue.offset + WHITESPACE_SEPARATOR + targetLibraryKeyword.length, modelName.length, fileName)
+					xtextDocument.replace(issue.offset, issue.length, fileName)
 				}
 			}
 		]
 	}
 }
-	

--- a/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.xtend
+++ b/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.xtend
@@ -26,19 +26,11 @@ import de.dlr.sc.overtarget.language.generator.util.ReferencedTargetHelper
 import org.eclipse.ui.IFileEditorInput
 import org.eclipse.core.runtime.NullProgressMonitor
 import de.dlr.sc.overtarget.language.targetmodel.TargetModel
-import de.dlr.sc.overtarget.language.targetmodel.impl.TargetmodelFactoryImpl
-import de.dlr.sc.overtarget.language.targetmodel.impl.TargetModelImpl
-import de.dlr.sc.overtarget.language.targetmodel.TargetmodelPackage
-import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.core.resources.IFile
 import org.eclipse.emf.common.util.URI
-import org.eclipse.core.resources.IProject
-import org.eclipse.emf.ecore.resource.ResourceSet
-import org.eclipse.ui.IEditorInput
-import org.eclipse.core.runtime.IProgressMonitor
-import de.dlr.sc.overtarget.language.targetmodel.impl.TargetmodelPackageImpl
 import org.eclipse.xtext.ui.resource.IResourceSetProvider
 import com.google.inject.Inject
+import de.dlr.sc.overtarget.language.targetmodel.TargetLibrary
+import de.dlr.sc.overtarget.language.targetmodel.TargetFile
 
 /**
  * Custom quickfixes.
@@ -102,34 +94,38 @@ class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
 	
 	@Fix(OvertargetValidator.FILE_NAME_LIKE_TARGET_NAME)
 	def fixFileNameLikeTargetName(Issue issue, IssueResolutionAcceptor acceptor) {
-			acceptor.accept(issue, 'Replace with correct tmodel name', '', 'upcase.png') [
-			
-			context |
-					val editor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor()
-					if (editor instanceof ITextEditor) {
-						val progressMonitor = new NullProgressMonitor()
-						editor.doSave(progressMonitor) //saves the made changes in the file
-						val ite = editor as ITextEditor
-						val input = ite.editorInput
-						val fileEditorInput = input as IFileEditorInput
-						val file = fileEditorInput.file
-						val uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
-						val project = file.getProject();
-						val rs = resourceSetProvider.get(project);
-						val r = rs.getResource(uri, true);
-						
-						val model = r.contents.get(0) as TargetModel
-						val modelName = model.name
-						
-						val targetKeyword = grammarAccess.KEYWORDAccess.targetKeyword_1.value
-						val targetLibraryKeyword = grammarAccess.targetLibraryRule.name
-						val WHITESPACE_SEPARATOR = 1
-						
-						val xtextDocument = context.xtextDocument
-						val fileName = editor.title.replace(".tmodel", "")
-						xtextDocument.replace(issue.offset + WHITESPACE_SEPARATOR + targetKeyword.length, modelName.length, fileName)
-					}
-			
+		acceptor.accept(issue, 'Replace with correct tmodel name', '', 'upcase.png') [
+		
+		context |
+			val editor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor()
+			if (editor instanceof ITextEditor) {
+				val progressMonitor = new NullProgressMonitor()
+				editor.doSave(progressMonitor) //saves the made changes in the file
+				val ite = editor as ITextEditor
+				val input = ite.editorInput
+				val fileEditorInput = input as IFileEditorInput
+				val file = fileEditorInput.file
+				val uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+				val project = file.getProject();
+				val rs = resourceSetProvider.get(project);
+				val r = rs.getResource(uri, true);
+				
+				val model = r.contents.get(0) as TargetFile
+				val modelName = model.name
+				
+				val targetKeyword = grammarAccess.KEYWORDAccess.targetKeyword_1.value
+				val targetLibraryKeyword = grammarAccess.targetLibraryRule.name
+				val WHITESPACE_SEPARATOR = 1
+				
+				val xtextDocument = context.xtextDocument
+				val fileName = editor.title.replace(".tmodel", "")
+				
+				if (model instanceof TargetModel) {
+					xtextDocument.replace(issue.offset + WHITESPACE_SEPARATOR + targetKeyword.length, modelName.length, fileName)
+				} else if (model instanceof TargetLibrary) {
+					xtextDocument.replace(issue.offset + WHITESPACE_SEPARATOR + targetLibraryKeyword.length, modelName.length, fileName)
+				}
+			}
 		]
 	}
 }

--- a/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.xtend
+++ b/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.xtend
@@ -14,7 +14,6 @@ import org.eclipse.xtext.validation.Issue
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionAcceptor
 import org.eclipse.xtext.ui.editor.quickfix.Fix
 import de.dlr.sc.overtarget.language.validation.OvertargetValidator
-import javax.inject.Inject
 import de.dlr.sc.overtarget.language.services.OvertargetGrammarAccess
 import de.dlr.sc.overtarget.language.ui.handler.GenerationHandler
 import org.eclipse.xtext.diagnostics.Diagnostic
@@ -26,6 +25,20 @@ import de.dlr.sc.overtarget.language.util.TargetPlatformHelper
 import de.dlr.sc.overtarget.language.generator.util.ReferencedTargetHelper
 import org.eclipse.ui.IFileEditorInput
 import org.eclipse.core.runtime.NullProgressMonitor
+import de.dlr.sc.overtarget.language.targetmodel.TargetModel
+import de.dlr.sc.overtarget.language.targetmodel.impl.TargetmodelFactoryImpl
+import de.dlr.sc.overtarget.language.targetmodel.impl.TargetModelImpl
+import de.dlr.sc.overtarget.language.targetmodel.TargetmodelPackage
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.core.resources.IFile
+import org.eclipse.emf.common.util.URI
+import org.eclipse.core.resources.IProject
+import org.eclipse.emf.ecore.resource.ResourceSet
+import org.eclipse.ui.IEditorInput
+import org.eclipse.core.runtime.IProgressMonitor
+import de.dlr.sc.overtarget.language.targetmodel.impl.TargetmodelPackageImpl
+import org.eclipse.xtext.ui.resource.IResourceSetProvider
+import com.google.inject.Inject
 
 /**
  * Custom quickfixes.
@@ -36,6 +49,7 @@ class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
 
 	@Inject
 	OvertargetGrammarAccess grammarAccess
+	
 
 	@Fix(OvertargetValidator.DEPRECATED_WS_STATEMENT)
 	def fixDeprecatedWsStatement(Issue issue, IssueResolutionAcceptor acceptor) {
@@ -82,4 +96,41 @@ class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
 			}
 		}, 1)
 	}
+	
+	@Inject
+	IResourceSetProvider resourceSetProvider
+	
+	@Fix(OvertargetValidator.FILE_NAME_LIKE_TARGET_NAME)
+	def fixFileNameLikeTargetName(Issue issue, IssueResolutionAcceptor acceptor) {
+			acceptor.accept(issue, 'Replace with correct tmodel name', '', 'upcase.png') [
+			
+			context |
+					val editor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor()
+					if (editor instanceof ITextEditor) {
+						val progressMonitor = new NullProgressMonitor()
+						editor.doSave(progressMonitor) //saves the made changes in the file
+						val ite = editor as ITextEditor
+						val input = ite.editorInput
+						val fileEditorInput = input as IFileEditorInput
+						val file = fileEditorInput.file
+						val uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+						val project = file.getProject();
+						val rs = resourceSetProvider.get(project);
+						val r = rs.getResource(uri, true);
+						
+						val model = r.contents.get(0) as TargetModel
+						val modelName = model.name
+						
+						val targetKeyword = grammarAccess.KEYWORDAccess.targetKeyword_1.value
+						val targetLibraryKeyword = grammarAccess.targetLibraryRule.name
+						val WHITESPACE_SEPARATOR = 1
+						
+						val xtextDocument = context.xtextDocument
+						val fileName = editor.title.replace(".tmodel", "")
+						xtextDocument.replace(issue.offset + WHITESPACE_SEPARATOR + targetKeyword.length, modelName.length, fileName)
+					}
+			
+		]
+	}
 }
+	

--- a/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.java
+++ b/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.java
@@ -9,14 +9,20 @@
  */
 package de.dlr.sc.overtarget.language.ui.quickfix;
 
+import com.google.inject.Inject;
 import de.dlr.sc.overtarget.language.generator.util.ReferencedTargetHelper;
 import de.dlr.sc.overtarget.language.services.OvertargetGrammarAccess;
+import de.dlr.sc.overtarget.language.targetmodel.TargetModel;
 import de.dlr.sc.overtarget.language.ui.handler.GenerationHandler;
 import de.dlr.sc.overtarget.language.util.TargetPlatformHelper;
 import de.dlr.sc.overtarget.language.validation.OvertargetValidator;
-import javax.inject.Inject;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
@@ -29,6 +35,7 @@ import org.eclipse.xtext.ui.editor.model.edit.IModificationContext;
 import org.eclipse.xtext.ui.editor.quickfix.DefaultQuickfixProvider;
 import org.eclipse.xtext.ui.editor.quickfix.Fix;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionAcceptor;
+import org.eclipse.xtext.ui.resource.IResourceSetProvider;
 import org.eclipse.xtext.validation.Issue;
 
 /**
@@ -85,5 +92,41 @@ public class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
           }
         }
       }, 1);
+  }
+  
+  @Inject
+  private IResourceSetProvider resourceSetProvider;
+  
+  @Fix(OvertargetValidator.FILE_NAME_LIKE_TARGET_NAME)
+  public void fixFileNameLikeTargetName(final Issue issue, final IssueResolutionAcceptor acceptor) {
+    final IModification _function = (IModificationContext context) -> {
+      final IEditorPart editor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
+      if ((editor instanceof ITextEditor)) {
+        final NullProgressMonitor progressMonitor = new NullProgressMonitor();
+        ((ITextEditor)editor).doSave(progressMonitor);
+        final ITextEditor ite = ((ITextEditor) editor);
+        final IEditorInput input = ite.getEditorInput();
+        final IFileEditorInput fileEditorInput = ((IFileEditorInput) input);
+        final IFile file = fileEditorInput.getFile();
+        final URI uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+        final IProject project = file.getProject();
+        final ResourceSet rs = this.resourceSetProvider.get(project);
+        final Resource r = rs.getResource(uri, true);
+        EObject _get = r.getContents().get(0);
+        final TargetModel model = ((TargetModel) _get);
+        final String modelName = model.getName();
+        final String targetKeyword = this.grammarAccess.getKEYWORDAccess().getTargetKeyword_1().getValue();
+        final String targetLibraryKeyword = this.grammarAccess.getTargetLibraryRule().getName();
+        final int WHITESPACE_SEPARATOR = 1;
+        final IXtextDocument xtextDocument = context.getXtextDocument();
+        final String fileName = ((ITextEditor)editor).getTitle().replace(".tmodel", "");
+        Integer _offset = issue.getOffset();
+        int _plus = ((_offset).intValue() + WHITESPACE_SEPARATOR);
+        int _length = targetKeyword.length();
+        int _plus_1 = (_plus + _length);
+        xtextDocument.replace(_plus_1, modelName.length(), fileName);
+      }
+    };
+    acceptor.accept(issue, "Replace with correct tmodel name", "", "upcase.png", _function);
   }
 }

--- a/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.java
+++ b/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.java
@@ -110,31 +110,19 @@ public class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
         final IEditorInput input = ite.getEditorInput();
         final IFileEditorInput fileEditorInput = ((IFileEditorInput) input);
         final IFile file = fileEditorInput.getFile();
+        final String fileName = file.getName().replace(".tmodel", "");
         final URI uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
         final IProject project = file.getProject();
         final ResourceSet rs = this.resourceSetProvider.get(project);
         final Resource r = rs.getResource(uri, true);
         EObject _get = r.getContents().get(0);
         final TargetFile model = ((TargetFile) _get);
-        final String modelName = model.getName();
-        final String targetKeyword = this.grammarAccess.getKEYWORDAccess().getTargetKeyword_1().getValue();
-        final String targetLibraryKeyword = this.grammarAccess.getTargetLibraryRule().getName();
-        final int WHITESPACE_SEPARATOR = 1;
         final IXtextDocument xtextDocument = context.getXtextDocument();
-        final String fileName = ((ITextEditor)editor).getTitle().replace(".tmodel", "");
         if ((model instanceof TargetModel)) {
-          Integer _offset = issue.getOffset();
-          int _plus = ((_offset).intValue() + WHITESPACE_SEPARATOR);
-          int _length = targetKeyword.length();
-          int _plus_1 = (_plus + _length);
-          xtextDocument.replace(_plus_1, modelName.length(), fileName);
+          xtextDocument.replace((issue.getOffset()).intValue(), (issue.getLength()).intValue(), fileName);
         } else {
           if ((model instanceof TargetLibrary)) {
-            Integer _offset_1 = issue.getOffset();
-            int _plus_2 = ((_offset_1).intValue() + WHITESPACE_SEPARATOR);
-            int _length_1 = targetLibraryKeyword.length();
-            int _plus_3 = (_plus_2 + _length_1);
-            xtextDocument.replace(_plus_3, modelName.length(), fileName);
+            xtextDocument.replace((issue.getOffset()).intValue(), (issue.getLength()).intValue(), fileName);
           }
         }
       }

--- a/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.java
+++ b/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/quickfix/OvertargetQuickfixProvider.java
@@ -12,6 +12,8 @@ package de.dlr.sc.overtarget.language.ui.quickfix;
 import com.google.inject.Inject;
 import de.dlr.sc.overtarget.language.generator.util.ReferencedTargetHelper;
 import de.dlr.sc.overtarget.language.services.OvertargetGrammarAccess;
+import de.dlr.sc.overtarget.language.targetmodel.TargetFile;
+import de.dlr.sc.overtarget.language.targetmodel.TargetLibrary;
 import de.dlr.sc.overtarget.language.targetmodel.TargetModel;
 import de.dlr.sc.overtarget.language.ui.handler.GenerationHandler;
 import de.dlr.sc.overtarget.language.util.TargetPlatformHelper;
@@ -113,18 +115,28 @@ public class OvertargetQuickfixProvider extends DefaultQuickfixProvider {
         final ResourceSet rs = this.resourceSetProvider.get(project);
         final Resource r = rs.getResource(uri, true);
         EObject _get = r.getContents().get(0);
-        final TargetModel model = ((TargetModel) _get);
+        final TargetFile model = ((TargetFile) _get);
         final String modelName = model.getName();
         final String targetKeyword = this.grammarAccess.getKEYWORDAccess().getTargetKeyword_1().getValue();
         final String targetLibraryKeyword = this.grammarAccess.getTargetLibraryRule().getName();
         final int WHITESPACE_SEPARATOR = 1;
         final IXtextDocument xtextDocument = context.getXtextDocument();
         final String fileName = ((ITextEditor)editor).getTitle().replace(".tmodel", "");
-        Integer _offset = issue.getOffset();
-        int _plus = ((_offset).intValue() + WHITESPACE_SEPARATOR);
-        int _length = targetKeyword.length();
-        int _plus_1 = (_plus + _length);
-        xtextDocument.replace(_plus_1, modelName.length(), fileName);
+        if ((model instanceof TargetModel)) {
+          Integer _offset = issue.getOffset();
+          int _plus = ((_offset).intValue() + WHITESPACE_SEPARATOR);
+          int _length = targetKeyword.length();
+          int _plus_1 = (_plus + _length);
+          xtextDocument.replace(_plus_1, modelName.length(), fileName);
+        } else {
+          if ((model instanceof TargetLibrary)) {
+            Integer _offset_1 = issue.getOffset();
+            int _plus_2 = ((_offset_1).intValue() + WHITESPACE_SEPARATOR);
+            int _length_1 = targetLibraryKeyword.length();
+            int _plus_3 = (_plus_2 + _length_1);
+            xtextDocument.replace(_plus_3, modelName.length(), fileName);
+          }
+        }
       }
     };
     acceptor.accept(issue, "Replace with correct tmodel name", "", "upcase.png", _function);

--- a/de.dlr.sc.overtarget.language/src/de/dlr/sc/overtarget/language/validation/OvertargetValidator.xtend
+++ b/de.dlr.sc.overtarget.language/src/de/dlr/sc/overtarget/language/validation/OvertargetValidator.xtend
@@ -31,7 +31,7 @@ class OvertargetValidator extends AbstractOvertargetValidator {
 		var helper = new ValidatorHelper();
 		val fileName = helper.getFileName(target);
 		if (!fileName.equals(target.name)) {
-			warning('File name and tmodel name are not the same!', target, target.eContainingFeature, FILE_NAME_LIKE_TARGET_NAME)
+			warning('File name and tmodel name are not the same!', target, TargetmodelPackage.eINSTANCE.targetFile_Name, FILE_NAME_LIKE_TARGET_NAME)
 		}
 	}
 	

--- a/de.dlr.sc.overtarget.language/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidator.java
+++ b/de.dlr.sc.overtarget.language/xtend-gen/de/dlr/sc/overtarget/language/validation/OvertargetValidator.java
@@ -36,7 +36,7 @@ public class OvertargetValidator extends AbstractOvertargetValidator {
     boolean _equals = fileName.equals(target.getName());
     boolean _not = (!_equals);
     if (_not) {
-      this.warning("File name and tmodel name are not the same!", target, target.eContainingFeature(), OvertargetValidator.FILE_NAME_LIKE_TARGET_NAME);
+      this.warning("File name and tmodel name are not the same!", target, TargetmodelPackage.eINSTANCE.getTargetFile_Name(), OvertargetValidator.FILE_NAME_LIKE_TARGET_NAME);
     }
   }
   


### PR DESCRIPTION
Whether the target file is a TargetModel or a TargetFile, the quick fix uses the file name and replaces the value after the keyword with the correct word.

![grafik](https://user-images.githubusercontent.com/56025362/82438041-b627f580-9a98-11ea-9161-132a6000af6d.png)


closes #90 