### PR TITLE
Fix bug complete Unit so that it shows all options in content assist

### DIFF
--- a/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/contentassist/OvertargetProposalProvider.xtend
+++ b/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/contentassist/OvertargetProposalProvider.xtend
@@ -9,19 +9,19 @@
  *******************************************************************************/
 package de.dlr.sc.overtarget.language.ui.contentassist
 
+import de.dlr.sc.overtarget.language.services.OvertargetGrammarAccess
+import de.dlr.sc.overtarget.language.targetmodel.RepositoryLocation
+import de.dlr.sc.overtarget.language.targetmodel.impl.UnitImpl
 import java.text.DateFormat
+import java.util.ArrayList
+import javax.inject.Inject
 import org.eclipse.core.runtime.Platform
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.Assignment
 import org.eclipse.xtext.RuleCall
+import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor
-import javax.inject.Inject
-import de.dlr.sc.overtarget.language.services.OvertargetGrammarAccess
-import java.util.ArrayList
-import de.dlr.sc.overtarget.language.targetmodel.impl.UnitImpl
-import de.dlr.sc.overtarget.language.targetmodel.RepositoryLocation
-import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal
 
 /**
  * See https://www.eclipse.org/Xtext/documentation/304_ide_concepts.html#content-assist
@@ -104,8 +104,7 @@ class OvertargetProposalProvider extends AbstractOvertargetProposalProvider {
 		ICompletionProposalAcceptor acceptor) {
 		val sourceProposals = new ArrayList
 		val unitManager = UnitManager.instance
-		val unit = model as UnitImpl
-		val reposLoc = unit.eContainer as RepositoryLocation
+		val reposLoc = unitManager.getRepositoryLocation(model)
 		val reposLocName = reposLoc.name
 		val listOfUnits = unitManager.getUnits(reposLocName)
 		if (listOfUnits !== null) {

--- a/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/contentassist/UnitManager.xtend
+++ b/de.dlr.sc.overtarget.language.ui/src/de/dlr/sc/overtarget/language/ui/contentassist/UnitManager.xtend
@@ -9,20 +9,21 @@
  *******************************************************************************/
 package de.dlr.sc.overtarget.language.ui.contentassist
 
-import java.util.HashMap
-import java.util.ArrayList
-import de.dlr.sc.overtarget.language.targetmodel.Unit
-import org.eclipse.core.runtime.jobs.Job
-import org.eclipse.core.runtime.IProgressMonitor
-import de.dlr.sc.overtarget.language.util.QueryManager
-import org.eclipse.core.runtime.Status
-import org.eclipse.core.runtime.CoreException
-import java.io.IOException
 import de.dlr.sc.overtarget.language.Activator
-import org.eclipse.ui.statushandlers.StatusManager
 import de.dlr.sc.overtarget.language.targetmodel.RepositoryLocation
-import org.eclipse.ui.PlatformUI
+import de.dlr.sc.overtarget.language.targetmodel.Unit
 import de.dlr.sc.overtarget.language.ui.OvertargetRunnableAdapter
+import de.dlr.sc.overtarget.language.util.QueryManager
+import java.io.IOException
+import java.util.ArrayList
+import java.util.HashMap
+import org.eclipse.core.runtime.CoreException
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.Status
+import org.eclipse.core.runtime.jobs.Job
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.ui.PlatformUI
+import org.eclipse.ui.statushandlers.StatusManager
 
 class UnitManager {
 	
@@ -98,5 +99,16 @@ class UnitManager {
 		}
 		job = Job.create("Loading units", runnable)
 		job.schedule();
+	}
+	
+	def getRepositoryLocation(EObject model) {
+		if (model instanceof RepositoryLocation) {
+			val reposLoc = model as RepositoryLocation
+			return reposLoc
+		} else if (model instanceof Unit) {
+			val unit = model as Unit
+			val reposLoc = unit.eContainer as RepositoryLocation
+			return reposLoc
+		}
 	}
 }

--- a/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/contentassist/OvertargetProposalProvider.java
+++ b/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/contentassist/OvertargetProposalProvider.java
@@ -143,9 +143,7 @@ public class OvertargetProposalProvider extends AbstractOvertargetProposalProvid
   public void complete_Source(final EObject model, final RuleCall ruleCall, final ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
     final ArrayList<Unit> sourceProposals = new ArrayList<Unit>();
     final UnitManager unitManager = UnitManager.getInstance();
-    final UnitImpl unit = ((UnitImpl) model);
-    EObject _eContainer = unit.eContainer();
-    final RepositoryLocation reposLoc = ((RepositoryLocation) _eContainer);
+    final RepositoryLocation reposLoc = unitManager.getRepositoryLocation(model);
     final String reposLocName = reposLoc.getName();
     final ArrayList<Unit> listOfUnits = unitManager.getUnits(reposLocName);
     if ((listOfUnits != null)) {

--- a/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/contentassist/UnitManager.java
+++ b/de.dlr.sc.overtarget.language.ui/xtend-gen/de/dlr/sc/overtarget/language/ui/contentassist/UnitManager.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -121,5 +122,20 @@ public class UnitManager {
     };
     this.job = Job.create("Loading units", this.runnable);
     this.job.schedule();
+  }
+  
+  public RepositoryLocation getRepositoryLocation(final EObject model) {
+    if ((model instanceof RepositoryLocation)) {
+      final RepositoryLocation reposLoc = ((RepositoryLocation) model);
+      return reposLoc;
+    } else {
+      if ((model instanceof Unit)) {
+        final Unit unit = ((Unit) model);
+        EObject _eContainer = unit.eContainer();
+        final RepositoryLocation reposLoc_1 = ((RepositoryLocation) _eContainer);
+        return reposLoc_1;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Sometimes auto completion either shows the statement "addAll" or shows all units but not both.
Unit Manager now checks if model is instance of repositoryLocation or unit, so all options are shown in content assist
![grafik](https://user-images.githubusercontent.com/56025362/154524563-7ba93829-c5ba-43e3-9ec8-3fbbdf59402e.png)
